### PR TITLE
Add ixAt, rename gettingIx to ixEQSet

### DIFF
--- a/ixset-typed.cabal
+++ b/ixset-typed.cabal
@@ -38,7 +38,8 @@ library
                      deepseq          >= 1.3 && < 2,
                      safecopy         >= 0.8 && < 1,
                      exceptions       >= 0.4 && < 1,
-                     microlens        >=0.4 && < 1
+                     microlens        >=0.4 && < 1,
+                     microlens-contra >= 0.1 && < 0.2
 
   hs-source-dirs:    src
   exposed-modules:


### PR DESCRIPTION
- Adds ixAt, which combines getEQ with folded.
- Renames gettingIx to the more descriptive ixEQSet
- Use microlens-contra to export 100% lens-compatible optics.