### PR TITLE
Split out and improve lenses, implement Optics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 cabal.sandbox.config
 dist
 *~
-ixset-*
+.stack-work
+dist-newstyle
+dist
+.ghc.environment.*

--- a/ixset-typed.cabal
+++ b/ixset-typed.cabal
@@ -1,7 +1,7 @@
 cabal-version:       3.0
 
 name:                ixset-typed
-version:             0.4
+version:             0.5
 synopsis:            Efficient relational queries on Haskell sets.
 description:
     This Haskell package provides a data structure of sets that are indexed
@@ -27,11 +27,11 @@ maintainer:          Andres Löh <andres@well-typed.com>
 category:            Data Structures
 build-type:          Simple
 extra-source-files:  CHANGELOG.md
-tested-with:         GHC == 8.0.1, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.1
+tested-with:         GHC == 8.6.5
 
 source-repository head
   type:              git
-  location:          https://github.com/well-typed/ixset-typed.git
+  location:          https://github.com/capital-match/ixset-typed.git
 
 library
   build-depends:     base             >= 4.9 && < 5,

--- a/ixset-typed.cabal
+++ b/ixset-typed.cabal
@@ -1,3 +1,5 @@
+cabal-version:       3.0
+
 name:                ixset-typed
 version:             0.4
 synopsis:            Efficient relational queries on Haskell sets.
@@ -18,13 +20,12 @@ description:
     At the moment, the two packages are relatively compatible. As a consequence
     of the more precise types, a few manual tweaks are necessary when switching
     from one to the other, but the interface is mostly the same.
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        COPYING
 author:              Andres Löh, Happstack team, HAppS LLC
 maintainer:          Andres Löh <andres@well-typed.com>
 category:            Data Structures
 build-type:          Simple
-cabal-version:       >= 1.10
 extra-source-files:  CHANGELOG.md
 tested-with:         GHC == 8.0.1, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.1
 
@@ -37,11 +38,9 @@ library
                      containers       >= 0.5.11 && < 1,
                      deepseq          >= 1.3 && < 2,
                      safecopy         >= 0.8 && < 1,
-                     exceptions       >= 0.4 && < 1,
-                     microlens        >=0.4 && < 1,
-                     microlens-contra >= 0.1 && < 0.2
+                     exceptions       >= 0.4 && < 1
 
-  hs-source-dirs:    src
+  hs-source-dirs:    src/main
   exposed-modules:
                      Data.IxSet.Typed
 
@@ -67,5 +66,33 @@ test-suite test-ixset-typed
   other-modules:     Data.IxSet.Typed.Tests
 
   ghc-options:       -Wall
+
+  default-language:  Haskell2010
+
+library ixset-optics-lens
+  visibility:        public
+  build-depends:     base             >= 4.9 && < 5,
+                     containers       >= 0.5 && < 1,
+                     lens >= 4.18,
+                     ixset-typed
+
+  hs-source-dirs:    src/ixset-optics-lens
+  exposed-modules:   Data.IxSet.Typed.Lens
+
+  ghc-options:       -Wall -Wredundant-constraints
+
+  default-language:  Haskell2010
+
+library ixset-optics-optics
+  visibility:        public
+  build-depends:     base             >= 4.9 && < 5,
+                     containers       >= 0.5 && < 1,
+                     optics >= 0.2,
+                     ixset-typed
+
+  hs-source-dirs:    src/ixset-optics-optics
+  exposed-modules:   Data.IxSet.Typed.Optics
+
+  ghc-options:       -Wall -Wredundant-constraints
 
   default-language:  Haskell2010

--- a/src/ixset-optics-lens/Data/IxSet/Typed/Lens.hs
+++ b/src/ixset-optics-lens/Data/IxSet/Typed/Lens.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+
+module Data.IxSet.Typed.Lens(
+  atPrimaryKey,
+  ixPrimaryKey,
+  eqKey,
+  eqKeys,
+  overEqKey,
+  asSet
+) where
+
+import Control.Lens
+import Data.IxSet.Typed as IS
+import Data.Set (Set)
+
+type GetIdx ixs ix a = (IS.Indexable ixs a, IS.IsIndexOf ix ixs)
+
+-- | Assuming the given GetIdx is a /primary key/, constructs a lens to access
+-- the value associated with the primary key. The getting operation uses 'getEQ'
+-- and 'getOne' and the setting operation uses 'updateIx' or 'deleteIx'.
+-- Therefore, this /will/ violate lens laws if the given GetIdx is not actually a
+-- primary key.
+atPrimaryKey :: GetIdx ixs ix a => ix -> Lens' (IxSet ixs a) (Maybe a)
+atPrimaryKey i = lens sa sbt
+  where
+    sa = getOne . getEQ i
+    {-# INLINE sa #-}
+
+    sbt s Nothing = deleteIx i s
+    sbt s (Just b) = updateIx i b s
+    {-# INLINE sbt #-}
+{-# INLINE atPrimaryKey #-}
+
+-- | Assuming the given GetIdx is a /primary key/, constructs a traversal to
+-- access the value associated with the primary key. This will not work when the
+-- provided GetIdx is not actually a primary key.
+ixPrimaryKey :: GetIdx ixs ix a => ix -> Traversal' (IxSet ixs a) a
+ixPrimaryKey i = atPrimaryKey i . _Just
+{-# INLINE ixPrimaryKey #-}
+
+-- | A fold over items at an index
+eqKey :: GetIdx ixs ix a => ix -> Fold (IxSet ixs a) a
+eqKey = folding . getEQ
+{-# INLINE eqKey #-}
+
+-- | A fold over items at indexes
+eqKeys :: GetIdx ixs ix a => [ix] -> Fold (IS.IxSet ixs a) a
+eqKeys k = folding (IS.@+ k)
+{-# INLINE eqKeys #-}
+
+-- | A simple getter for getEQ. Returns a filtered IxSet
+overEqKey :: GetIdx ixs ix a => ix -> Getter (IxSet ixs a) (IxSet ixs a)
+overEqKey = to . getEQ
+{-# INLINE overEqKey #-}
+
+-- | Turn an IxSet into a Set
+asSet :: Getter (IxSet ixs a) (Set a)
+asSet = to toSet
+{-# INLINE asSet #-}
+

--- a/src/ixset-optics-optics/Data/IxSet/Typed/Optics.hs
+++ b/src/ixset-optics-optics/Data/IxSet/Typed/Optics.hs
@@ -1,11 +1,18 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Data.IxSet.Typed.Optics where
+module Data.IxSet.Typed.Optics(
+  atPrimaryKey,
+  ixPrimaryKey,
+  ixKey,
+  ixKeys,
+  atKey,
+  asSet
+) where
 
 import Control.Applicative
 import Data.IxSet.Typed as IS
-import qualified Data.Set as Set
+import Data.Set (Set)
 import Optics
 
 type GetIdx ixs ix a = (Indexable ixs a, IsIndexOf ix ixs)
@@ -55,6 +62,6 @@ atKey k = lens (getEQ k) (\ixs b -> IS.union b $ IS.difference ixs (getEQ k ixs)
 {-# INLINE atKey #-}
 
 -- | Isomorphism from IxSet to Set
-asSet :: Indexable ixs a => Iso' (IxSet ixs a) (Set.Set a)
+asSet :: Indexable ixs a => Iso' (IxSet ixs a) (Set a)
 asSet = iso toSet fromSet
 {-# INLINE asSet #-}

--- a/src/ixset-optics-optics/Data/IxSet/Typed/Optics.hs
+++ b/src/ixset-optics-optics/Data/IxSet/Typed/Optics.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.IxSet.Typed.Optics where
+
+import Control.Applicative
+import Data.IxSet.Typed as IS
+import qualified Data.Set as Set
+import Optics
+
+type GetIdx ixs ix a = (Indexable ixs a, IsIndexOf ix ixs)
+
+-- | Assuming the given GetIdx is a /primary key/, constructs a lens to access
+-- the value associated with the primary key. The getting operation uses 'getEQ'
+-- and 'getOne' and the setting operation uses 'updateIx' or 'deleteIx'.
+-- Therefore, this /will/ violate lens laws if the given GetIdx is not actually a
+-- primary key.
+atPrimaryKey :: GetIdx ixs ix a => ix -> Lens' (IxSet ixs a) (Maybe a)
+atPrimaryKey i = lens sa sbt
+  where
+    sa = getOne . getEQ i
+    {-# INLINE sa #-}
+
+    sbt s Nothing = deleteIx i s
+    sbt s (Just b) = updateIx i b s
+    {-# INLINE sbt #-}
+{-# INLINE atPrimaryKey #-}
+
+-- | Assuming the given GetIdx is a /primary key/, constructs a traversal to
+-- access the value associated with the primary key. This will not work when the
+-- provided GetIdx is not actually a primary key.
+ixPrimaryKey :: GetIdx ixs ix a => ix -> AffineTraversal' (IS.IxSet ixs a) a
+ixPrimaryKey k = atPrimaryKey k % _Just
+{-# INLINE ixPrimaryKey #-}
+
+traverseWith :: Indexable ixs a => (IxSet ixs a -> IxSet ixs a) -> Traversal' (IxSet ixs a) a
+traverseWith ixsFilter = traversalVL $ \f ixs -> let sa = ixsFilter ixs in foldr (liftA2 IS.insert . f) (pure $ IS.difference ixs sa) sa
+{-# INLINE traverseWith #-}
+
+-- | A traversal over items at an idx
+-- It is only a valid traversal if the Eq instance of 'a' is a good citizen, particularly that it expresses substitutivity.
+ixKey :: GetIdx ixs ix a => ix -> Traversal' (IxSet ixs a) a
+ixKey = traverseWith . getEQ
+{-# INLINE ixKey #-}
+
+-- | A traversal over items at indexes
+-- It is only a valid traversal if the Eq instance of 'a' is a good citizen, particularly that it expresses substitutivity.
+ixKeys :: GetIdx ixs ix a => [ix] -> Traversal' (IS.IxSet ixs a) a
+ixKeys = traverseWith . flip (IS.@+)
+{-# INLINE ixKeys #-}
+
+-- | Get or set the contained IxSet at a given index.
+atKey :: GetIdx ixs ix a => ix -> Lens' (IS.IxSet ixs a) (IS.IxSet ixs a)
+atKey k = lens (getEQ k) (\ixs b -> IS.union b $ IS.difference ixs (getEQ k ixs))
+{-# INLINE atKey #-}
+
+-- | Isomorphism from IxSet to Set
+asSet :: Indexable ixs a => Iso' (IxSet ixs a) (Set.Set a)
+asSet = iso toSet fromSet
+{-# INLINE asSet #-}

--- a/src/main/Data/IxSet/Typed/Ix.hs
+++ b/src/main/Data/IxSet/Typed/Ix.hs
@@ -7,6 +7,7 @@ module Data.IxSet.Typed.Ix
     , deleteList
     , union
     , intersection
+    , difference
     , filterFrom
     )
     where
@@ -15,6 +16,7 @@ import Control.DeepSeq
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import Data.Map.Merge.Strict
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Prelude hiding (filter)
@@ -71,6 +73,13 @@ intersection :: (Ord a, Ord k)
              => Map k (Set a) -> Map k (Set a) -> Map k (Set a)
 intersection index1 index2 = Map.filter (not . Set.null) $
                              Map.intersectionWith Set.intersection index1 index2
+
+-- | Takes the difference of two sets.
+difference :: (Ord a, Ord k)
+             => Map k (Set a) -> Map k (Set a) -> Map k (Set a)
+difference index1 index2 = Map.differenceWith diff index1 index2
+  where diff set1 set2 = let diffSet = Set.difference set1 set2 in
+                            if Set.null diffSet then Nothing else Just diffSet
 
 -- | Filters the sets by restricting to the elements in the provided set.
 filterFrom :: (Ord a) => Set a -> Map k (Set a) -> Map k (Set a)

--- a/src/main/Data/IxSet/Typed/Ix.hs
+++ b/src/main/Data/IxSet/Typed/Ix.hs
@@ -16,7 +16,6 @@ import Control.DeepSeq
 import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import Data.Map.Merge.Strict
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Prelude hiding (filter)


### PR DESCRIPTION
- Splits out lens-implemented optics to a separate sub-library, and adds a sub-library for pure Optics implementation. -> Requires cabal 3
- Implements IS.difference for subtracting IxSets.