### PR TITLE
Specialized containers

### DIFF
--- a/ixset-typed.cabal
+++ b/ixset-typed.cabal
@@ -36,6 +36,8 @@ source-repository head
 library
   build-depends:     base             >= 4.9 && < 5,
                      containers       >= 0.5.11 && < 1,
+                     unordered-containers       ,
+                     hashable,
                      deepseq          >= 1.3 && < 2,
                      safecopy         >= 0.8 && < 1,
                      exceptions       >= 0.4 && < 1,
@@ -44,6 +46,7 @@ library
   hs-source-dirs:    src/main
   exposed-modules:
                      Data.IxSet.Typed
+                     Data.IxSet.Typed.Container
 
   other-modules:
                      Data.IxSet.Typed.Ix
@@ -61,6 +64,7 @@ test-suite test-ixset-typed
                      QuickCheck,
                      tasty,
                      tasty-hunit,
+                     time,
                      tasty-quickcheck
   hs-source-dirs:    tests
   main-is:           TestIxSetTyped.hs
@@ -69,6 +73,24 @@ test-suite test-ixset-typed
   ghc-options:       -Wall
 
   default-language:  Haskell2010
+
+executable  ixset-typed-bench
+  type:              exitcode-stdio-1.0
+  build-depends:     ixset-typed,
+                     base             >= 4.9 && < 5,
+                     containers       >= 0.5 && < 1,
+                     HUnit,
+                     QuickCheck,
+                     tasty,
+                     tasty-hunit,
+                     time,
+                     tasty-quickcheck
+  main-is:           test.hs
+
+  ghc-options:       -Wall
+
+  default-language:  Haskell2010
+
 
 library ixset-optics-lens
   visibility:        public

--- a/src/ixset-optics-lens/Data/IxSet/Typed/Lens.hs
+++ b/src/ixset-optics-lens/Data/IxSet/Typed/Lens.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Data.IxSet.Typed.Lens(
   atPrimaryKey,
@@ -15,7 +16,7 @@ import Control.Lens
 import Data.IxSet.Typed as IS
 import Data.Set (Set)
 
-type GetIdx ixs ix a = (IS.Indexable ixs a, IS.IsIndexOf ix ixs)
+type GetIdx ixs ix a = (IS.Indexed a ix,IS.Indexable ixs a, IS.IsIndexOf a ix ixs, Eq (IndexType a ix))
 
 -- | Assuming the given GetIdx is a /primary key/, constructs a lens to access
 -- the value associated with the primary key. The getting operation uses 'getEQ'

--- a/src/ixset-optics-lens/Data/IxSet/Typed/Lens.hs
+++ b/src/ixset-optics-lens/Data/IxSet/Typed/Lens.hs
@@ -16,7 +16,7 @@ import Control.Lens
 import Data.IxSet.Typed as IS
 import Data.Set (Set)
 
-type GetIdx ixs ix a = (IS.Indexed a ix,IS.Indexable ixs a, IS.IsIndexOf a ix ixs, Eq (IndexType a ix))
+type GetIdx ixs ix a = (IS.Indexed a ix,IS.Indexable ixs a,AllIxType a IxContainerMinimal ixs, IxContainer (IndexType a ix), IS.IsIndexOf a ix ixs, Eq (IndexType a ix))
 
 -- | Assuming the given GetIdx is a /primary key/, constructs a lens to access
 -- the value associated with the primary key. The getting operation uses 'getEQ'
@@ -41,7 +41,7 @@ ixPrimaryKey :: GetIdx ixs ix a => ix -> Traversal' (IxSet ixs a) a
 ixPrimaryKey i = atPrimaryKey i . _Just
 {-# INLINE ixPrimaryKey #-}
 
-traverseWith :: IS.Indexable ixs a => (IxSet ixs a -> IxSet ixs a) -> Traversal' (IxSet ixs a) a
+traverseWith :: (AllIxType a IxContainerMinimal ixs,IS.Indexable ixs a) => (IxSet ixs a -> IxSet ixs a) -> Traversal' (IxSet ixs a) a
 traverseWith ixsFilter f ixs = let sa = ixsFilter ixs in foldr (liftA2 IS.insert . f) (pure $ IS.difference ixs sa) sa
 {-# INLINE traverseWith #-}
 

--- a/src/ixset-optics-optics/Data/IxSet/Typed/Optics.hs
+++ b/src/ixset-optics-optics/Data/IxSet/Typed/Optics.hs
@@ -16,7 +16,7 @@ import Data.IxSet.Typed as IS
 import Data.Set (Set)
 import Optics
 
-type GetIdx ixs ix a = (Indexed a ix, Indexable ixs a, IsIndexOf a ix ixs, Eq (IndexType a ix))
+type GetIdx ixs ix a = (Indexed a ix, Indexable ixs a, IsIndexOf a ix ixs, AllIxType a IxContainerMinimal ixs, IxContainer (IndexType a ix), Eq (IndexType a ix))
 
 -- | Assuming the given GetIdx is a /primary key/, constructs a lens to access
 -- the value associated with the primary key. The getting operation uses 'getEQ'
@@ -41,7 +41,7 @@ ixPrimaryKey :: GetIdx ixs ix a => ix -> AffineTraversal' (IS.IxSet ixs a) a
 ixPrimaryKey k = atPrimaryKey k % _Just
 {-# INLINE ixPrimaryKey #-}
 
-traverseWith :: Indexable ixs a => (IxSet ixs a -> IxSet ixs a) -> Traversal' (IxSet ixs a) a
+traverseWith :: (AllIxType a IxContainerMinimal ixs,Indexable ixs a) => (IxSet ixs a -> IxSet ixs a) -> Traversal' (IxSet ixs a) a
 traverseWith ixsFilter = traversalVL $ \f ixs -> let sa = ixsFilter ixs in foldr (liftA2 IS.insert . f) (pure $ IS.difference ixs sa) sa
 {-# INLINE traverseWith #-}
 

--- a/src/ixset-optics-optics/Data/IxSet/Typed/Optics.hs
+++ b/src/ixset-optics-optics/Data/IxSet/Typed/Optics.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Data.IxSet.Typed.Optics(
   atPrimaryKey,
@@ -15,7 +16,7 @@ import Data.IxSet.Typed as IS
 import Data.Set (Set)
 import Optics
 
-type GetIdx ixs ix a = (Indexable ixs a, IsIndexOf ix ixs)
+type GetIdx ixs ix a = (Indexed a ix, Indexable ixs a, IsIndexOf a ix ixs, Eq (IndexType a ix))
 
 -- | Assuming the given GetIdx is a /primary key/, constructs a lens to access
 -- the value associated with the primary key. The getting operation uses 'getEQ'

--- a/src/main/Data/IxSet/Typed.hs
+++ b/src/main/Data/IxSet/Typed.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 {- |
@@ -125,6 +128,8 @@ module Data.IxSet.Typed
      updateIx,
      updateUnique,
      deleteIx,
+     Container.Polymorphic(..),
+     IxContainer,
      deleteUnique,
      alterIx,
      filter,
@@ -169,6 +174,7 @@ module Data.IxSet.Typed
      (@*),
      getEQ,
      lookup,
+     member,
      getLT,
      getGT,
      getLTE,
@@ -182,7 +188,6 @@ module Data.IxSet.Typed
 
      -- * Joins
      Joined(..),
-     innerJoinUsing,
 
      -- * Debugging and optimization
      forceIndexesPar,
@@ -197,18 +202,15 @@ import Control.Arrow (first, second)
 import Control.DeepSeq
 import Control.Monad.Catch
 import Data.Either
-import Data.Foldable (Foldable)
 import qualified Data.Foldable as Fold
-import Data.IxSet.Typed.Ix (Ix (Ix))
+import Data.IxSet.Typed.Ix (Indexed(..),IndexType,Ix (Ix))
+import Data.IxSet.Typed.Container (OrderedContainer, IxContainer, Container)
+import qualified Data.IxSet.Typed.Container as Container
 import qualified Data.IxSet.Typed.Ix as Ix
 import qualified Data.List as List
-import Data.Map (Map)
-import qualified Data.Map as Map
-import qualified Data.Map.Merge.Lazy as MM
 import Data.Maybe (fromMaybe)
-import Data.Monoid (Monoid (mappend, mempty))
+import Data.Coerce
 import Data.SafeCopy (SafeCopy (..), contain, safeGet, safePut)
-import Data.Semigroup (Semigroup (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Control.Parallel.Strategies
@@ -271,44 +273,49 @@ type family All (c :: * -> Constraint) (xs :: [*]) :: Constraint
 type instance All c '[]       = ()
 type instance All c (x ': xs) = (c x, All c xs)
 
+type family AllIxType a (c :: * -> Constraint) (xs :: [*]) :: Constraint
+type instance AllIxType a c '[]       = ()
+type instance AllIxType a c (x ': xs) = (c (IndexType a x), AllIxType a c xs)
+
+
 -- | 'Indexable' is a convenient shorthand for the instances that are necessary
 -- to use 'IxSet'. If you want to use @'IxSet' ixs a@, you need
 --
 -- * An 'Ord' instance for @a@
 -- * An 'Ord' instance for each @ix@ in @ixs@
 -- * An 'Indexed' instance for @a@ and each @ix@ in @ixs@
-type Indexable ixs a = (All Ord ixs, All (Indexed a) ixs, Ord a, MkEmptyIxList ixs)
+type Indexable ixs a = (AllIxType a IxContainer ixs , AllIxType a Ord ixs, All (Indexed a) ixs, Ord a, MkEmptyIxList a ixs)
 
 
 -- | Operations related to the type-level list of index types.
-class Ord ix => IsIndexOf (ix :: *) (ixs :: [*]) where
+class (IxContainer (IndexType a ix)) => IsIndexOf a (ix :: *) (ixs :: [*]) where
 
   -- | Provide access to the selected index in the list.
   access :: IxList ixs a -> Ix ix a
 
-  -- | Map over the index list, treating the selected different
+  -- | Container over the index list, treating the selected different
   -- from the rest.
   --
   -- The function 'mapAt' is lazy in the index list structure,
   -- because it is used by query operations.
-  mapAt :: (All Ord ixs, All (Indexed a) ixs)
+  mapAt :: (AllIxType a IxContainer ixs ,AllIxType a Ord ixs, All (Indexed a) ixs)
         => (Indexed a ix => Ix ix a -> Ix ix a)
               -- ^ what to do with the selected index
-        -> (forall ix'. (Indexed a ix', Ord ix') => Ix ix' a -> Ix ix' a)
+        -> (forall ix'. (IxContainer (IndexType a ix'), Indexed a ix') => Ix ix' a -> Ix ix' a)
               -- ^ what to do with the other indices
         -> IxList ixs a -> IxList ixs a
 
 instance
   {-# OVERLAPPING #-}
-  Ord ix => IsIndexOf ix (ix ': ixs) where
+  (IxContainer (IndexType a ix)) => IsIndexOf a ix (ix ': ixs) where
   access (x ::: _xs)     = x
   mapAt fh ft (x ::: xs) = fh x ::: mapIxList ft xs
 
 instance
   {-# OVERLAPPABLE #-}
-  IsIndexOf ix ixs => IsIndexOf ix (ix' ': ixs) where
+  IsIndexOf a ix ixs => IsIndexOf a ix (ix' ': ixs) where
   access (_x ::: xs)     = access xs
-  mapAt fh ft (x ::: xs) = ft x ::: mapAt fh ft xs
+  mapAt fh ft (x ::: xs) = ft x ::: mapAt @a @ix @ixs fh ft xs
 
 -- | Return the length of an index list.
 --
@@ -323,24 +330,24 @@ lengthIxList = go 0
 
 -- | Turn an index list into a normal list, given a function that
 -- turns an arbitrary index into an element of a fixed type @r@.
-ixListToList :: All Ord ixs
-             => (forall ix. Ord ix => Ix ix a -> r)
+ixListToList :: (AllIxType a IxContainer ixs, AllIxType a Ord ixs)
+             => (forall ix. (IxContainer (IndexType a ix)) => Ix ix a -> r)
                   -- ^ what to do with each index
              -> IxList ixs a -> [r]
 ixListToList _ Nil        = []
 ixListToList f (x ::: xs) = f x : ixListToList f xs
 
--- | Map over an index list.
-mapIxList :: (All Ord ixs, All (Indexed a) ixs)
-          => (forall ix. (Indexed a ix, Ord ix) => Ix ix a -> Ix ix a)
+-- | Container over an index list.
+mapIxList :: (AllIxType a IxContainer  ixs , AllIxType a Ord ixs, All (Indexed a) ixs)
+          => (forall ix. (IxContainer (IndexType a ix), Indexed a ix) => Ix ix a -> Ix ix a)
                 -- ^ what to do with each index
           -> IxList ixs a -> IxList ixs a
 mapIxList _ Nil        = Nil
 mapIxList f (x ::: xs) = f x ::: mapIxList f xs
 {-# INLINE mapIxList #-}
 
--- | Map over an index list (spine-strict).
-mapIxListPar' :: (All Ord ixs, All (Indexed a) ixs)
+-- | Container over an index list (spine-strict).
+mapIxListPar' :: (AllIxType a Ord ixs, All (Indexed a) ixs)
            =>
                  -- ^ what to do with each index
            IxList ixs a -> Eval (IxList ixs a)
@@ -351,9 +358,9 @@ mapIxListPar'  (x ::: xs) = do
   return (x' ::: xs')
 {-# INLINE mapIxListPar' #-}
 
--- | Map over an index list (spine-strict).
-mapIxList' :: (All Ord ixs, All (Indexed a) ixs)
-           => (forall ix. (Indexed a ix, Ord ix) => Ix ix a -> Ix ix a)
+-- | Container over an index list (spine-strict).
+mapIxList' :: (AllIxType a IxContainer ixs, AllIxType a Ord ixs, All (Indexed a) ixs)
+           => (forall ix. (IxContainer (IndexType a ix), Indexed a ix) => Ix ix a -> Ix ix a)
                  -- ^ what to do with each index
            -> IxList ixs a -> IxList ixs a
 mapIxList' _ Nil        = Nil
@@ -362,8 +369,8 @@ mapIxList' f (x ::: xs) = f x !::: mapIxList' f xs
 
 
 -- | Zip two index lists of compatible type (spine-strict).
-zipWithIxList' :: (All Ord ixs, All (Indexed a) ixs)
-               => (forall ix. (Indexed a ix, Ord ix) => Ix ix a -> Ix ix a -> Ix ix a)
+zipWithIxList' :: (AllIxType a IxContainer ixs, AllIxType a Ord ixs, All (Indexed a) ixs)
+               => (forall ix. (IxContainer (IndexType a ix) , Indexed a ix) => Ix ix a -> Ix ix a -> Ix ix a)
                     -- ^ how to combine two corresponding indices
                -> IxList ixs a -> IxList ixs a -> IxList ixs a
 zipWithIxList' _ Nil        Nil        = Nil
@@ -389,12 +396,12 @@ instance (Indexable ixs a, Read a) => Read (IxSet ixs a) where
 instance (Typeable ixs, Typeable a, Indexable ixs a, SafeCopy a) => SafeCopy (IxSet ixs a) where
   putCopy = contain . safePut . toList
   getCopy = contain $ fmap fromList safeGet
-
-instance (All NFData ixs, NFData a) => NFData (IxList ixs a) where
+ 
+instance (AllIxType a IxContainer ixs ,  All NFData ixs, NFData a) => NFData (IxList ixs a) where
   rnf Nil        = ()
-  rnf (x ::: xs) = rnf x `seq` rnf xs
+  rnf (Ix x ::: xs) = rnf1 x `seq` rnf xs
 
-instance (All NFData ixs, NFData a) => NFData (IxSet ixs a) where
+instance (AllIxType a IxContainer ixs, All NFData ixs, NFData a) => NFData (IxSet ixs a) where
   rnf (IxSet a ixs) = rnf a `seq` rnf ixs
 
 instance Indexable ixs a => Semigroup (IxSet ixs a) where
@@ -440,19 +447,16 @@ empty = IxSet Set.empty mkEmptyIxList
 -- used internally because instances provide a way to do case analysis on a
 -- type-level list. If you see an error message about this constraint not being
 -- satisfied, make sure the @ixs@ argument to 'Indexable' is a type-level list.
-class MkEmptyIxList (ixs :: [*]) where
+class MkEmptyIxList a (ixs :: [*]) where
   mkEmptyIxList :: IxList ixs a
-instance MkEmptyIxList '[] where
+instance MkEmptyIxList a '[] where
   mkEmptyIxList = Nil
-instance MkEmptyIxList ixs => MkEmptyIxList (ix ': ixs) where
-  mkEmptyIxList = (Ix Map.empty) ::: mkEmptyIxList
+instance (IxContainer (IndexType a ix) , MkEmptyIxList a ixs) => MkEmptyIxList a (ix ': ixs) where
+  mkEmptyIxList = (Ix Container.empty) ::: mkEmptyIxList
 
 -- | An 'Indexed' class asserts that it is possible to extract indices of type
 -- @ix@ from a type @a@. Provided function should return a list of indices where
 -- the value should be found. There are no predefined instances for 'Indexed'.
-class Indexed a ix where
-  ixFun :: a -> [ix]
-
 --------------------------------------------------------------------------
 -- Modification of 'IxSet's
 --------------------------------------------------------------------------
@@ -461,87 +465,93 @@ type SetOp =
     forall a. Ord a => a -> Set a -> Set a
 
 type IndexOp =
-    forall k a. (Ord k,Ord a) => k -> a -> Map k (Set a) -> Map k (Set a)
+    forall k a. (IxContainer k,Ord a) => k -> a -> Container k (Set a) -> Container k (Set a)
 
 -- | Higher order operator for modifying 'IxSet's.  Use this when your
 -- final function should have the form @a -> 'IxSet' a -> 'IxSet' a@,
 -- e.g. 'insert' or 'delete'.
 change :: forall ixs a. Indexable ixs a
        => SetOp -> IndexOp -> a -> IxSet ixs a -> IxSet ixs a
-change opS opI x (IxSet a indexes) = IxSet (opS x a) v
+change !opS !opI x (IxSet a indexes) = IxSet (opS x a) v
   where
     v :: IxList ixs a
     v = mapIxList' update indexes
 
-    update :: forall ix. (Indexed a ix, Ord ix) => Ix ix a -> Ix ix a
+    update :: forall ix. (IxContainer (IndexType a ix), Indexed a ix) => Ix ix a -> Ix ix a
     update (Ix index) = Ix index'
       where
-        ds :: [ix]
-        ds = ixFun x
-        ii :: forall k. Ord k => Map k (Set a) -> k -> Map k (Set a)
+        ii :: forall k . (IxContainer k) => Container k (Set a) -> k -> Container k (Set a)
         ii m dkey = opI dkey x m
-        index' :: Map ix (Set a)
-        index' = List.foldl' ii index ds
+        index' :: Container (IndexType a ix) (Set a)
+        index' = List.foldl' ii index (ixFunRep @a @ix x) 
 {-# INLINE change #-}
 
-insertList :: forall ixs a. Indexable ixs a
+insertList :: forall ixs a. (AllIxType a IxContainer ixs , AllIxType a Ord ixs, All (Indexed a) ixs, Ord a)
            => [a] -> IxSet ixs a -> IxSet ixs a
-insertList xs (IxSet a indexes) = IxSet (List.foldl' (\ b x -> Set.insert x b) a xs) v
+insertList xs (IxSet a indexes) = IxSet (List.foldl' (\ b x -> Set.insert x b) a xs) ( mapIxList' update indexes)
   where
-    v :: IxList ixs a
-    v = mapIxList' update indexes
 
-    update :: forall ix. (Indexed a ix, Ord ix) => Ix ix a -> Ix ix a
+    update :: forall ix. (IxContainer (IndexType a ix) ,Indexed a ix) => Ix ix a -> Ix ix a
     update (Ix index) = Ix index'
       where
-        index' :: Map ix (Set a)
-        index' = List.foldl' (\m v -> List.foldl' (\m' k-> Ix.insert k v m') m (ixFun v)) index xs
+        index' :: Container (IndexType a ix) (Set a)
+        index' = List.foldl' (\m v -> List.foldl' (\m' k-> Ix.insert k v m') m (ixFunRep @a @ix v)) index xs
 
 -- | Internal helper function that takes a partial index from one index
 -- set and rebuilds the rest of the structure of the index set.
 --
 -- Slightly rewritten comment from original version regarding dss / index':
 --
--- We try to be really clever here. The partialindex is a Map of Sets
+-- We try to be really clever here. The partialindex is a Container of Sets
 -- from original index. We want to reuse it as much as possible. If there
 -- was a guarantee that each element is present at at most one key we
 -- could reuse originalindex as it is. But there can be more, so we need to
 -- add remaining ones (in updateh). Anyway we try to reuse old structure and
 -- keep new allocations low as much as possible.
-fromMapOfSet :: forall ixs ix a. (Indexable ixs a, IsIndexOf ix ixs)
+fromContainerOfSet :: forall ixs ix a. (Eq (IndexType a ix), Indexable ixs a, IsIndexOf a ix ixs)
               => ix -> Set a -> IxSet ixs a
-fromMapOfSet v a =
-    IxSet a (mapAt updateh updatet mkEmptyIxList)
+fromContainerOfSet v a =
+    IxSet a (mapAt @a @ix @ixs updateh updatet mkEmptyIxList)
   where
 
     -- Update function for the index corresponding to partialindex.
-    updateh :: Indexed a ix => Ix ix a -> Ix ix a
+    updateh :: (Indexed a ix) => Ix ix a -> Ix ix a
     updateh (Ix _) = Ix ix
       where
-        dss :: [(ix, a)]
-        dss = [(k, x) | x <- Set.toList a, k <- ixFun x, k /= v ]
+        dss :: [(IndexType a ix, a)]
+        dss = do 
+            x <- Set.toList a
+            let reps = ixFunRep @a @ix x
+            if length reps > 1
+              then  do 
+                k <- reps 
+                if (k /=  ixRep @a @ix v) 
+                then return (k,x)
+                else [] 
+            else []
 
-        ix :: Map ix (Set a)
-        ix = Ix.insertList dss (Map.singleton v a)
+
+        ix :: Container (IndexType a ix) (Set a)
+        ix = Ix.insertList dss (Container.singleton (ixRep @a @ix v) a)
 
 
 
     -- Update function for all other indices.
-    updatet :: forall ix'. (Indexed a ix', Ord ix') => Ix ix' a -> Ix ix' a
+    updatet :: forall ix'. (IxContainer (IndexType a ix'), Indexed a ix') => Ix ix' a -> Ix ix' a
     updatet (Ix _) = Ix ix
       where
-        ix :: Map ix' (Set a)
-        ix = List.foldl' (\m v -> List.foldl' (\m' k-> Ix.insert k v m') m (ixFun v)) Map.empty (Set.toList a)
-{-# INLINE fromMapOfSet #-}
+        ix :: Container (IndexType a ix') (Set a)
+        ix = List.foldl' (\m v' -> List.foldl' (\m' k-> Ix.insert k v' m') m (ixFunRep @a @ix' v')) Container.empty (Set.toList a)
+{-# INLINE fromContainerOfSet #-}
 
 
-fromMapOfSets :: forall ixs ix a. (Indexable ixs a, IsIndexOf ix ixs)
-              => Map ix (Set a) -> IxSet ixs a
-fromMapOfSets partialindex =
-    IxSet a (mapAt updateh updatet mkEmptyIxList)
+fromContainerOfSets :: forall ixs ix a. (Indexable ixs a, IsIndexOf a ix ixs)
+              => Container (IndexType a ix) (Set a) -> IxSet ixs a
+fromContainerOfSets partialindex =
+    IxSet a (mapAt @a @ix @ixs updateh updatet mkEmptyIxList)
   where
     a :: Set a
-    a = nonEmptyFoldl (Map.elems partialindex)
+    a = nonEmptyFoldl (Container.elems partialindex)
     nonEmptyFoldl (i:xs) = List.foldl' Set.union i xs
     nonEmptyFoldl  [] = Set.empty
 
@@ -550,37 +560,37 @@ fromMapOfSets partialindex =
     updateh :: Indexed a ix => Ix ix a -> Ix ix a
     updateh (Ix _) = Ix ix
       where
-        dss :: [(ix, a)]
-        dss = [(k, x) | x <- Set.toList a, k <- ixFun x, not (Map.member k partialindex)]
+        dss :: [(IndexType a ix, a)]
+        dss = [(k, x) | x <- Set.toList a, k <- ixFunRep @a @ix x, not (Container.member k partialindex)]
 
-        ix :: Map ix (Set a)
+        ix :: Container (IndexType a ix) (Set a)
         ix = Ix.insertList dss partialindex
 
     -- Update function for all other indices.
-    updatet :: forall ix'. (Indexed a ix', Ord ix') => Ix ix' a -> Ix ix' a
+    updatet :: forall ix'. (IxContainer (IndexType a ix'), Indexed a ix' ) => Ix ix' a -> Ix ix' a
     updatet (Ix _) = Ix ix
       where
-        dss :: [(ix', a)]
-        dss = [(k, x) | x <- Set.toList a, k <- ixFun x]
+        dss :: [(IndexType a ix', a)]
+        dss = [(k, x) | x <- Set.toList a, k <- ixFunRep @a @ix' x]
 
-        ix :: Map ix' (Set a)
+        ix :: Container (IndexType a ix') (Set a)
         ix = Ix.fromList dss
-{-# INLINE fromMapOfSets #-}
+{-# INLINE fromContainerOfSets #-}
 
 -- | Inserts an item into the 'IxSet'. If your data happens to have a primary
 -- key this function is most likely /not/ what you want. In this case, use
 -- 'updateIx' instead.
 insert :: Indexable ixs a => a -> IxSet ixs a -> IxSet ixs a
 insert = change Set.insert Ix.insert
-{-# INLINABLE insert #-}
+{-# INLINE insert #-}
 
 -- | Removes an item from the 'IxSet'.
 delete :: Indexable ixs a => a -> IxSet ixs a -> IxSet ixs a
 delete = change Set.delete Ix.delete
-{-# INLINABLE delete #-}
+{-# INLINE delete #-}
 
 -- | Internal implementation for update* family
-updateIx' :: (Indexable ixs a, IsIndexOf ix ixs, MonadThrow m)
+updateIx' :: (Eq (IndexType a ix), Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs, MonadThrow m)
          => (IxSet ixs a -> m (Maybe a)) -> ix -> a -> IxSet ixs a -> m (IxSet ixs a)
 updateIx' get i new ixset = do
   existing <- get $ ixset @= i
@@ -590,7 +600,7 @@ updateIx' get i new ixset = do
 {-# INLINE updateIx' #-}
 
 -- | Internal implementation for delete* family
-deleteIx' :: (Indexable ixs a, IsIndexOf ix ixs, MonadThrow m)
+deleteIx' :: (Eq (IndexType a ix), Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs, MonadThrow m)
          => (IxSet ixs a -> m (Maybe a)) -> ix -> IxSet ixs a -> m (IxSet ixs a)
 deleteIx' get i ixset = do
   existing <- get $ ixset @= i
@@ -601,16 +611,16 @@ deleteIx' get i ixset = do
 -- | Will replace the item with the given index of type 'ix'.
 -- Only works if there is at most one item with that index in the 'IxSet'.
 -- Will not change 'IxSet' if you have more than one item with given index.
-updateIx :: (Indexable ixs a, IsIndexOf ix ixs)
+updateIx :: (Eq (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
          => ix -> a -> IxSet ixs a -> IxSet ixs a
 updateIx i new ixset = fromRight ixset $ updateIx' (Right . getOne) i new ixset
-{-# INLINABLE updateIx #-}
+{-# INLINE updateIx #-}
 
 
 -- | Will replace the item with the given index of type 'ix'.
 -- Only works if there is at most one item with that index in the 'IxSet'.
 -- Will not change 'IxSet' if you have more than one item with given index.
-alterIx :: (Indexable ixs a, IsIndexOf ix ixs)
+alterIx :: (Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
          => ix -> (Maybe a -> Maybe a)  -> IxSet ixs a -> (IxSet ixs a, (Maybe a, Maybe a))
 alterIx i f ixset =
   let existing = lookup i ixset
@@ -618,7 +628,7 @@ alterIx i f ixset =
   in ((maybe id insert new) $
     maybe ixset (flip delete ixset) $
     existing,(existing,new))
-{-# INLINABLE alterIx #-}
+{-# INLINE alterIx #-}
 
 -- | Will replace the item with the given index of type 'ix'.
 -- Only works if there is at most one item with that index in the 'IxSet'.
@@ -626,17 +636,17 @@ alterIx i f ixset =
 
 -- Throws: 'NotUniqueException
 
-updateUnique :: (Indexable ixs a, IsIndexOf ix ixs, MonadThrow m)
+updateUnique :: (Eq (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs, MonadThrow m)
          => ix -> a -> IxSet ixs a -> m (IxSet ixs a)
 updateUnique = updateIx' getUnique
 
 -- | Will delete the item with the given index of type 'ix'.
 -- Only works if there is at  most one item with that index in the 'IxSet'.
 -- Will not change 'IxSet' if you have more than one item with given index.
-deleteIx :: (Indexable ixs a, IsIndexOf ix ixs)
+deleteIx :: (Eq (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
          => ix -> IxSet ixs a -> IxSet ixs a
 deleteIx i ixset = fromRight ixset $ deleteIx' (Right . getOne) i ixset
-{-# INLINABLE deleteIx #-}
+{-# INLINE deleteIx #-}
 
 -- | Will delete the item with the given index of type 'ix'.
 -- Only works if there is at  most one item with that index in the 'IxSet'.
@@ -644,7 +654,7 @@ deleteIx i ixset = fromRight ixset $ deleteIx' (Right . getOne) i ixset
 
 -- Throws: 'NotUniqueException
 
-deleteUnique :: (Indexable ixs a, IsIndexOf ix ixs, MonadThrow m)
+deleteUnique :: (Eq (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs, MonadThrow m)
          => ix -> IxSet ixs a -> m (IxSet ixs a)
 deleteUnique = deleteIx' getUnique
 
@@ -659,7 +669,7 @@ filter f (IxSet a il) = IxSet a' il'
     a' = Set.filter f a
     il' = mapIxList update il
       where
-        update :: forall ix. Ix ix a -> Ix ix a
+        update :: forall ix. IxContainer (IndexType a ix) => Ix ix a -> Ix ix a
         update (Ix ix) = Ix (Ix.filterFrom a' ix)
 
 --------------------------------------------------------------------------
@@ -677,14 +687,14 @@ fromSet set = IxSet set v
     v :: IxList ixs a
     v = mapIxList mkIx mkEmptyIxList
 
-    mkIx :: forall ix. (Indexed a ix, Ord ix) => Ix ix a -> Ix ix a
-    mkIx (Ix _) = Ix (List.foldl' (\m v -> List.foldl' (\m' k-> Ix.insert k v m') m (ixFun v)) Map.empty (Set.toList set))
-{-# INLINABLE fromSet #-}
+    mkIx :: forall ix. (IxContainer (IndexType a ix), Indexed a ix) => Ix ix a -> Ix ix a
+    mkIx (Ix _) = Ix $ Ix.fromSet (ixFunRep @a @ix) set 
+{-# INLINE fromSet #-}
 
 -- | Converts a list to an 'IxSet'.
 fromList :: (Indexable ixs a) => [a] -> IxSet ixs a
 fromList list = insertList list empty
-{-# INLINABLE fromList #-}
+{-# INLINE fromList #-}
 
 -- | Returns the number of unique items in the 'IxSet'.
 size :: IxSet ixs a -> Int
@@ -701,7 +711,7 @@ toList = Set.toList . toSet
 -- instance.
 --
 -- The list may contain duplicate entries if a single value produces multiple keys.
-toAscList :: forall proxy ix ixs a. IsIndexOf ix ixs => proxy ix -> IxSet ixs a -> [a]
+toAscList :: forall proxy ix ixs a. (OrderedContainer (IndexType a ix), Coercible ix (IndexType a ix) , IsIndexOf a ix ixs) => proxy ix -> IxSet ixs a -> [a]
 toAscList _ ixset = concatMap snd (groupAscBy ixset :: [(ix, [a])])
 
 -- | Converts an 'IxSet' to its list of elements.
@@ -711,7 +721,7 @@ toAscList _ ixset = concatMap snd (groupAscBy ixset :: [(ix, [a])])
 -- instance.
 --
 -- The list may contain duplicate entries if a single value produces multiple keys.
-toDescList :: forall proxy ix ixs a. IsIndexOf ix ixs => proxy ix -> IxSet ixs a -> [a]
+toDescList :: forall proxy ix ixs a. (OrderedContainer (IndexType a ix) , Coercible ix (IndexType a ix) , IsIndexOf a ix ixs) => proxy ix -> IxSet ixs a -> [a]
 toDescList _ ixset = concatMap snd (groupDescBy ixset :: [(ix, [a])])
 
 -- | Converts an 'IxSet' to its list of elements.
@@ -721,7 +731,7 @@ toDescList _ ixset = concatMap snd (groupDescBy ixset :: [(ix, [a])])
 -- instance.
 --
 -- The list may contain duplicate entries if a single value produces multiple keys.
-toFullDescList :: forall proxy ix ixs a. IsIndexOf ix ixs => proxy ix -> IxSet ixs a -> [a]
+toFullDescList :: forall proxy ix ixs a. (OrderedContainer (IndexType a ix),Coercible ix (IndexType a ix) , IsIndexOf a ix ixs) => proxy ix -> IxSet ixs a -> [a]
 toFullDescList _ ixset = concatMap snd (groupFullDescBy ixset :: [(ix, [a])])
 
 -- | If the 'IxSet' is a singleton it will return the one item stored in it.
@@ -789,58 +799,58 @@ difference (IxSet a1 x1) (IxSet a2 x2) =
 --------------------------------------------------------------------------
 
 -- | Infix version of 'getEQ'.
-(@=) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@=) :: (Eq (IndexType a ix), Indexable ixs a, Indexed a ix , IsIndexOf a ix ixs)
      => IxSet ixs a -> ix -> IxSet ixs a
 ix @= v = getEQ v ix
 
 -- | Infix version of 'getLT'.
-(@<) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@<) :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
      => IxSet ixs a -> ix -> IxSet ixs a
 ix @< v = getLT v ix
 
 -- | Infix version of 'getGT'.
-(@>) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@>) :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
      => IxSet ixs a -> ix -> IxSet ixs a
 ix @> v = getGT v ix
 
 -- | Infix version of 'getLTE'.
-(@<=) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@<=) :: (OrderedContainer (IndexType a ix), Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
       => IxSet ixs a -> ix -> IxSet ixs a
 ix @<= v = getLTE v ix
 
 -- | Infix version of 'getGTE'.
-(@>=) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@>=) :: (OrderedContainer (IndexType a ix), Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
       => IxSet ixs a -> ix -> IxSet ixs a
 ix @>= v = getGTE v ix
 
 -- | Returns the subset with indices in the open interval (k,k).
-(@><) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@><) :: (OrderedContainer (IndexType a ix), Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
       => IxSet ixs a -> (ix, ix) -> IxSet ixs a
 ix @>< (v1,v2) = getLT v2 $ getGT v1 ix
 
 -- | Returns the subset with indices in [k,k).
-(@>=<) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@>=<) :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
        => IxSet ixs a -> (ix, ix) -> IxSet ixs a
 ix @>=< (v1,v2) = getLT v2 $ getGTE v1 ix
 
 -- | Returns the subset with indices in (k,k].
-(@><=) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@><=) :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
        => IxSet ixs a -> (ix, ix) -> IxSet ixs a
 ix @><= (v1,v2) = getLTE v2 $ getGT v1 ix
 
 -- | Returns the subset with indices in [k,k].
-(@>=<=) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@>=<=) :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
         => IxSet ixs a -> (ix, ix) -> IxSet ixs a
 ix @>=<= (v1,v2) = getLTE v2 $ getGTE v1 ix
 
 -- | Creates the subset that has an index in the provided list.
-(@+) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@+) :: (Eq (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
      => IxSet ixs a -> [ix] -> IxSet ixs a
 ix @+ [e] = ix @= e
 ix @+ list = List.foldl' union  empty $  map (ix @=) list
 
 -- | Creates the subset that matches all the provided indices.
-(@*) :: (Indexable ixs a, IsIndexOf ix ixs)
+(@*) :: (Eq (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
      => IxSet ixs a -> [ix] -> IxSet ixs a
 ix @* [e]= ix @=  e
 ix @* list = List.foldl' intersection ix $ map (ix @=) list
@@ -852,28 +862,28 @@ ix @* list = List.foldl' intersection ix $ map (ix @=) list
 -- | Returns the subset with an index less than the provided key.  The
 -- set must be indexed over key type, doing otherwise results in
 -- a compile error.
-getLT :: (Indexable ixs a, IsIndexOf ix ixs)
+getLT :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
       => ix -> IxSet ixs a -> IxSet ixs a
-getLT = getOrd LT
+getLT = getOrd2 True False False
 
 -- | Returns the subset with an index greater than the provided key.
 -- The set must be indexed over key type, doing otherwise results in
 -- a compile error.
-getGT :: (Indexable ixs a, IsIndexOf ix ixs)
+getGT :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
       => ix -> IxSet ixs a -> IxSet ixs a
-getGT = getOrd GT
+getGT = getOrd2 False False True
 
 -- | Returns the subset with an index less than or equal to the
 -- provided key.  The set must be indexed over key type, doing
 -- otherwise results in a compile error.
-getLTE :: (Indexable ixs a, IsIndexOf ix ixs)
+getLTE :: (OrderedContainer (IndexType a ix), Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
        => ix -> IxSet ixs a -> IxSet ixs a
 getLTE = getOrd2 True True False
 
 -- | Returns the subset with an index greater than or equal to the
 -- provided key.  The set must be indexed over key type, doing
 -- otherwise results in a compile error.
-getGTE :: (Indexable ixs a, IsIndexOf ix ixs)
+getGTE :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
        => ix -> IxSet ixs a -> IxSet ixs a
 getGTE = getOrd2 False True True
 
@@ -881,112 +891,118 @@ getGTE = getOrd2 False True True
 -- The bottom of the interval is closed and the top is open,
 -- i. e. [k1;k2).  The set must be indexed over key type, doing
 -- otherwise results in a compile error.
-getRange :: (Indexable ixs a, IsIndexOf ix ixs)
+getRange :: (OrderedContainer (IndexType a ix),Indexed a ix ,Indexable ixs a, IsIndexOf a ix ixs)
          => ix -> ix -> IxSet ixs a -> IxSet ixs a
 getRange k1 k2 ixset = getGTE k1 (getLT k2 ixset)
 
 -- | Returns lists of elements paired with the indices determined by
 -- type inference.
-groupBy :: forall ix ixs a. IsIndexOf ix ixs => IxSet ixs a -> [(ix, [a])]
+groupBy :: forall ix ixs a. (Coercible ix (IndexType a ix) , IsIndexOf a ix ixs ) => IxSet ixs a -> [(ix, [a])]
 groupBy (IxSet _ indexes) = f (access indexes)
   where
     f :: Ix ix a -> [(ix, [a])]
-    f (Ix index) = map (second Set.toList) (Map.toList index)
+    f (Ix index) = map (coerce . second Set.toList) (Container.toList index)
 
 -- | Returns the list of index keys being used for a particular index.
-indexKeys :: forall ix ixs a . IsIndexOf ix ixs => IxSet ixs a -> [ix]
+indexKeys :: forall ix ixs a . (Coercible ix (IndexType a ix) ,IxContainer (IndexType a ix), IsIndexOf a ix ixs) => IxSet ixs a -> [ix]
 indexKeys (IxSet _ indexes) = f (access indexes)
   where
     f :: Ix ix a -> [ix]
-    f (Ix index) = Map.keys index
+    f (Ix index) = coerce $ Container.keys index
 
 -- | Returns lists of elements paired with the indices determined by
 -- type inference.
 --
 -- The resulting list will be sorted in ascending order by 'ix'.
 -- The values in @[a]@ will be sorted in ascending order as well.
-groupAscBy :: forall ix ixs a. IsIndexOf ix ixs =>  IxSet ixs a -> [(ix, [a])]
+groupAscBy :: forall ix ixs a. (Coercible ix (IndexType a ix) ,OrderedContainer (IndexType a ix), IsIndexOf a ix ixs) =>  IxSet ixs a -> [(ix, [a])]
 groupAscBy (IxSet _ indexes) = f (access indexes)
   where
     f :: Ix ix a -> [(ix, [a])]
-    f (Ix index) = map (second Set.toAscList) (Map.toAscList index)
+    f (Ix index) = map (coerce . second Set.toAscList) (Container.toAscList index)
 
 -- | Returns lists of elements paired with the indices determined by
 -- type inference.
 --
 -- The resulting list will be sorted in descending order by 'ix'.
 -- The values in @[a]@ will, however, be sorted in /ascending/ order.
-groupDescBy :: IsIndexOf ix ixs =>  IxSet ixs a -> [(ix, [a])]
+groupDescBy :: forall ix ixs a. (OrderedContainer (IndexType a ix),Coercible ix (IndexType a ix) ,IsIndexOf a ix ixs) =>  IxSet ixs a -> [(ix, [a])]
 groupDescBy (IxSet _ indexes) = f (access indexes)
   where
     f :: Ix ix a -> [(ix, [a])]
-    f (Ix index) = map (second Set.toAscList) (Map.toDescList index)
+    f (Ix index) = map (coerce . second Set.toAscList) (Container.toDescList index)
 
 -- | Returns lists of elements paired with the indices determined by
 -- type inference.
 --
 -- The resulting list will be sorted in descending order by 'ix'.
 -- The values in @[a]@ will also be sorted in descending order.
-groupFullDescBy :: IsIndexOf ix ixs =>  IxSet ixs a -> [(ix, [a])]
+groupFullDescBy :: (OrderedContainer (IndexType a ix),Coercible ix (IndexType a ix) ,IsIndexOf a ix ixs) =>  IxSet ixs a -> [(ix, [a])]
 groupFullDescBy (IxSet _ indexes) = f (access indexes)
   where
-    f :: Ix ix a -> [(ix, [a])]
-    f (Ix index) = map (second Set.toDescList) (Map.toDescList index)
+    f :: forall ix a . (OrderedContainer (IndexType a ix), Coercible ix (IndexType a ix))  =>  Ix ix a -> [(ix, [a])]
+    f (Ix index) = map (coerce . second Set.toDescList) (Container.toDescList index)
 
 -- | A function for building up selectors on 'IxSet's.  Used in the
 -- various get* functions.  The set must be indexed over key type,
 -- doing otherwise results in a compile error.
 
-getOrd :: (Indexable ixs a, IsIndexOf ix ixs)
-       => Ordering -> ix -> IxSet ixs a -> IxSet ixs a
-getOrd LT = getOrd2 True False False
-getOrd EQ = getEQ
-getOrd GT = getOrd2 False False True
-
-getEQ :: forall ixs ix a. (Indexable ixs a, IsIndexOf ix ixs)
+getEQ :: forall ixs ix a. (Eq (IndexType a ix), Indexed a ix , Indexable ixs a, IsIndexOf a ix ixs)
         => ix -> IxSet ixs a -> IxSet ixs a
 getEQ v (IxSet _ ixs) =  f (access ixs)
   where
     f :: Ix ix a -> IxSet ixs a
-    f (Ix index) = maybe empty (fromMapOfSet v) $ Map.lookup v index
-{-# INLINABLE  getEQ #-}
+    f (Ix index) = maybe empty (fromContainerOfSet v) $ Container.lookup (ixRep @a @ix v) index
+{-# INLINE getEQ #-}
 
-lookup :: forall ixs ix a. IsIndexOf ix ixs
+member :: forall ixs ix a. (Indexed a ix , IsIndexOf a ix ixs) 
+        => ix -> IxSet ixs a -> Bool 
+member v (IxSet _ ixs) =  f (access ixs)
+  where
+    f :: Ix ix a -> Bool 
+    f (Ix index) = Container.member (ixRep @a @ix v) index
+{-# INLINE member #-}
+
+
+lookup :: forall ixs ix a. (Indexed a ix , IsIndexOf a ix ixs) 
         => ix -> IxSet ixs a -> Maybe a
 lookup v (IxSet _ ixs) =  f (access ixs)
   where
     f :: Ix ix a -> Maybe a
-    f (Ix index) = case Set.toList <$> (Map.lookup v index) of
+    f (Ix index) = case Set.toList <$> (Container.lookup (ixRep @a @ix v) index) of
                         Just [x] -> Just x
                         _ -> Nothing
-{-# INLINABLE  lookup#-}
+{-# INLINE lookup#-}
 
 -- | A function for building up selectors on 'IxSet's.  Used in the
 -- various get* functions.  The set must be indexed over key type,
 -- doing otherwise results in a compile error.
-getOrd2 :: forall ixs ix a. (Indexable ixs a, IsIndexOf ix ixs)
+getOrd2 :: forall ixs ix a . ( Indexed a ix 
+                             , OrderedContainer (IndexType a ix)
+                             , Indexable ixs a
+                             , IsIndexOf a ix ixs)
         => Bool -> Bool -> Bool -> ix -> IxSet ixs a -> IxSet ixs a
 getOrd2 inclt inceq incgt v (IxSet _ ixs) = f (access ixs)
   where
     f :: Ix ix a -> IxSet ixs a
-    f (Ix index) = fromMapOfSets result
+    f (Ix index) = fromContainerOfSets @ixs @ix @a result
       where
-        lt', gt' :: Map ix (Set a)
+        lt', gt' :: Container (IndexType a ix) (Set a)
         eq' :: Maybe (Set a)
-        (lt', eq', gt') = Map.splitLookup v index
+        (lt', eq', gt') = Container.splitLookup (ixRep @a @ix v) index
 
-        lt, gt :: Map ix (Set a)
-        lt = if inclt then lt' else Map.empty
-        gt = if incgt then gt' else Map.empty
+        lt, gt :: Container (IndexType a ix) (Set a)
+        lt = if inclt then lt' else Container.empty
+        gt = if incgt then gt' else Container.empty
         eq :: Maybe (Set a)
         eq = if inceq then eq' else Nothing
 
-        ltgt :: Map ix (Set a)
-        ltgt = Map.unionWith Set.union lt gt
+        ltgt :: Container (IndexType a ix) (Set a)
+        ltgt = Container.unionWith Set.union lt gt
 
-        result :: Map ix (Set a)
+        result :: Container (IndexType a ix) (Set a)
         result = case eq of
-          Just eqset -> Map.insertWith Set.union v eqset ltgt
+          Just eqset -> Container.insertWith Set.union (ixRep @a @ix v) eqset ltgt
           Nothing    -> ltgt
 
 --------------------------------------------------------------------------
@@ -995,27 +1011,9 @@ getOrd2 inclt inceq incgt v (IxSet _ ixs) = f (access ixs)
 
 newtype Joined a b = Joined (a, b) deriving (Show, Read, Eq, Ord)
 
-instance (Indexed a ix, Indexed b ix) => Indexed (Joined a b) ix where
+instance (Coercible (IndexType (Joined a b) ix) ix, Indexed a ix, Indexed b ix) => Indexed (Joined a b) ix where
   ixFun (Joined (a, b)) = ixFun a <> ixFun b
 
--- | Perform an inner join between two tables using a specific index. The
--- expression @'innerJoinUsing' s1 s2 (Proxy :: Proxy t)@ is similar in purpose
--- to the SQL expression @SELECT * FROM s1 INNER JOIN s2 USING (t)@. The
--- resulting 'IxSet' can contain any index type @ix@ for which the instances
--- @'Indexed' a ix@ and @'Indexed' b ix@ exist.
-innerJoinUsing ::
-     forall ixs1 ixs2 ixs3 a b proxy ix.
-     (Indexable ixs3 (Joined a b), IsIndexOf ix ixs1, IsIndexOf ix ixs2, IsIndexOf ix ixs3)
-  => IxSet ixs1 a
-  -> IxSet ixs2 b
-  -> proxy ix
-  -> IxSet ixs3 (Joined a b)
-innerJoinUsing (IxSet _ ixs1) (IxSet _ ixs2) _ = f (access ixs1) (access ixs2)
-  where
-    f :: Ix ix a -> Ix ix b -> IxSet ixs3 (Joined a b)
-    f (Ix m1) (Ix m2) =
-      fromMapOfSets
-        (MM.merge MM.dropMissing MM.dropMissing (MM.zipWithMatched (\_ a b -> Set.mapMonotonic Joined (Set.cartesianProduct a b))) m1 m2)
 
 -- Optimization todo:
 --
@@ -1043,8 +1041,8 @@ stats (IxSet a ixs) = (no_elements,no_indexes,no_keys,no_values)
     where
       no_elements = Set.size a
       no_indexes  = lengthIxList ixs
-      no_keys     = sum (ixListToList (\ (Ix m) -> Map.size m) ixs)
-      no_values   = sum (ixListToList (\ (Ix m) -> sum [Set.size s | s <- Map.elems m]) ixs)
+      no_keys     = sum (ixListToList (\ (Ix m) -> Container.size m) ixs)
+      no_values   = sum (ixListToList (\ (Ix m) -> sum [Set.size s | s <- Container.elems m]) ixs)
 
 forceIndexesSeq :: Indexable ixs a => IxSet ixs a -> IxSet ixs a
 forceIndexesSeq (IxSet a ixs)= IxSet a (mapIxList' id ixs)

--- a/src/main/Data/IxSet/Typed/Container.hs
+++ b/src/main/Data/IxSet/Typed/Container.hs
@@ -11,22 +11,24 @@ module Data.IxSet.Typed.Container where
 import Control.DeepSeq 
 
 import qualified Data.Map as Map 
+import qualified Data.Map.Strict as SMap 
+import qualified Data.HashMap.Strict as SHashMap 
 import qualified Data.HashMap.Lazy as HashMap 
 import Data.Hashable
 import qualified Data.IntMap as IntMap 
+import qualified Data.IntMap.Strict as SIntMap 
 
 class NFData1 (Container k) =>  IxContainerMinimal k where
   type Container k = (c :: * -> * ) |   c -> k
   alter :: (Maybe a -> Maybe a) -> k -> Container k a -> Container k a
   empty :: Container k a 
+  lookup :: k -> Container k a -> Maybe a 
 
 class IxContainerMinimal k  =>  IxContainer k where
-  singleton ::  k -> a -> Container k a
   size :: Container k a  -> Int
   elems :: Container k a -> [a]
   keys :: Container k a -> [k]
   toList :: Container k a -> [(k,a)]
-  lookup :: k -> Container k a -> Maybe a 
   member :: k -> Container k a -> Bool
   insert :: k -> a -> Container k a -> Container k a
   insertWith  :: (a -> a -> a) -> k -> a -> Container k a -> Container k a
@@ -35,7 +37,6 @@ class IxContainerMinimal k  =>  IxContainer k where
   differenceWith ::  (a -> a -> Maybe a ) -> Container k a -> Container k a  -> Container k a
   unionWith :: (a -> a -> a) -> Container k a -> Container k a  -> Container k a
   intersectionWith :: (a -> a -> a) -> Container k a -> Container k a -> Container k a 
-  update :: (a -> Maybe a) -> k -> Container k a -> Container k a
 
 class IxContainer k =>  OrderedContainer k where
   toAscList :: Container k a -> [(k,a)]
@@ -50,30 +51,28 @@ instance NFData1 (Map.Map a) where
 
 instance  Ord a => IxContainerMinimal (Polymorphic  a) where
   type Container (Polymorphic a) = Map.Map (Polymorphic  a)
-  alter = Map.alter
+  alter = SMap.alter
   {-# INLINE alter #-}
-  empty = Map.empty
+  empty = SMap.empty
+  lookup = Map.lookup
+  {-# INLINE lookup #-}
 
 instance  Ord a => IxContainer (Polymorphic  a) where
-  singleton = Map.singleton
   size = Map.size
   elems = Map.elems
   keys = Map.keys
   toList = Map.toList
   member = Map.member
   {-# INLINE member #-}
-  lookup = Map.lookup
-  {-# INLINE lookup #-}
-  insert = Map.insert
+  insert = SMap.insert
   {-# INLINE insert #-}
-  insertWith = Map.insertWith
+  insertWith = SMap.insertWith
   {-# INLINE insertWith #-}
   mapMaybe = Map.mapMaybe
   filter = Map.filter
-  differenceWith = Map.differenceWith
-  unionWith = Map.unionWith
-  intersectionWith = Map.intersectionWith
-  update = Map.update
+  differenceWith = SMap.differenceWith
+  unionWith = SMap.unionWith
+  intersectionWith = SMap.intersectionWith
 
 instance Ord a => OrderedContainer (Polymorphic a ) where
   toAscList = Map.toAscList
@@ -85,30 +84,28 @@ instance NFData1 IntMap.IntMap  where
 
 instance  IxContainerMinimal Int where
   type Container Int = IntMap.IntMap
-  empty = IntMap.empty
-  alter = IntMap.alter
+  empty = SIntMap.empty
+  alter = SIntMap.alter
   {-# INLINE alter #-}
+  lookup = IntMap.lookup
+  {-# INLINE lookup #-}
 
 instance  IxContainer Int where
-  singleton = IntMap.singleton
   size = IntMap.size
   elems = IntMap.elems
   keys = IntMap.keys
   toList = IntMap.toList
   member = IntMap.member
   {-# INLINE member #-}
-  lookup = IntMap.lookup
-  {-# INLINE lookup #-}
-  insert = IntMap.insert
+  insert = SIntMap.insert
   {-# INLINE insert #-}
-  insertWith = IntMap.insertWith
+  insertWith = SIntMap.insertWith
   {-# INLINE insertWith #-}
   mapMaybe = IntMap.mapMaybe
   filter = IntMap.filter
-  differenceWith = IntMap.differenceWith
-  unionWith = IntMap.unionWith
-  intersectionWith = IntMap.intersectionWith
-  update = IntMap.update
+  differenceWith = SIntMap.differenceWith
+  unionWith = SIntMap.unionWith
+  intersectionWith = SIntMap.intersectionWith
 
 
 instance  OrderedContainer Int where
@@ -121,28 +118,26 @@ instance NFData1 (HashMap.HashMap a) where
 
 instance  (Eq a, Hashable a) => IxContainerMinimal (HashPolymorphic a) where
   type Container (HashPolymorphic a) = HashMap.HashMap (HashPolymorphic a)
-  empty = HashMap.empty
-  alter = HashMap.alter
+  empty = SHashMap.empty
+  alter = SHashMap.alter
   {-# INLINE alter #-}
+  lookup = HashMap.lookup
+  {-# INLINE lookup #-}
 
 instance  (Eq a, Hashable a) => IxContainer (HashPolymorphic a) where
-  singleton = HashMap.singleton
   size = HashMap.size
   elems = HashMap.elems
   keys = HashMap.keys
   toList = HashMap.toList
   member = HashMap.member
   {-# INLINE member #-}
-  lookup = HashMap.lookup
-  {-# INLINE lookup #-}
-  insert = HashMap.insert
+  insert = SHashMap.insert
   {-# INLINE insert #-}
-  insertWith = HashMap.insertWith
+  insertWith = SHashMap.insertWith
   {-# INLINE insertWith #-}
   mapMaybe = HashMap.mapMaybe
   filter = HashMap.filter
-  differenceWith = HashMap.differenceWith
-  unionWith = HashMap.unionWith
-  intersectionWith = HashMap.intersectionWith
-  update = HashMap.update
+  differenceWith = SHashMap.differenceWith
+  unionWith = SHashMap.unionWith
+  intersectionWith = SHashMap.intersectionWith
 

--- a/src/main/Data/IxSet/Typed/Container.hs
+++ b/src/main/Data/IxSet/Typed/Container.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+module Data.IxSet.Typed.Container where
+
+import Control.DeepSeq 
+
+import qualified Data.Map as Map 
+import qualified Data.HashMap.Lazy as HashMap 
+import Data.Hashable
+import qualified Data.IntMap as IntMap 
+
+class NFData1 (Container k) =>  IxContainerMinimal k where
+  type Container k = (c :: * -> * ) |   c -> k
+  alter :: (Maybe a -> Maybe a) -> k -> Container k a -> Container k a
+  empty :: Container k a 
+
+class IxContainerMinimal k  =>  IxContainer k where
+  singleton ::  k -> a -> Container k a
+  size :: Container k a  -> Int
+  elems :: Container k a -> [a]
+  keys :: Container k a -> [k]
+  toList :: Container k a -> [(k,a)]
+  lookup :: k -> Container k a -> Maybe a 
+  member :: k -> Container k a -> Bool
+  insert :: k -> a -> Container k a -> Container k a
+  insertWith  :: (a -> a -> a) -> k -> a -> Container k a -> Container k a
+  mapMaybe :: (a -> Maybe b) -> Container k a -> Container k b
+  filter :: (a -> Bool) -> Container k a  -> Container k a
+  differenceWith ::  (a -> a -> Maybe a ) -> Container k a -> Container k a  -> Container k a
+  unionWith :: (a -> a -> a) -> Container k a -> Container k a  -> Container k a
+  intersectionWith :: (a -> a -> a) -> Container k a -> Container k a -> Container k a 
+  update :: (a -> Maybe a) -> k -> Container k a -> Container k a
+
+class IxContainer k =>  OrderedContainer k where
+  toAscList :: Container k a -> [(k,a)]
+  toDescList :: Container k a -> [(k,a)]
+  splitLookup :: k -> Container k a -> (Container k a, Maybe a, Container k a)
+
+newtype Polymorphic a = Polymorphic a deriving(Eq,Ord,NFData,Num,Show,Read)
+newtype HashPolymorphic a = HashPolymorphic a deriving(Eq,Ord,NFData,Num,Show,Read,Hashable)
+
+instance NFData1 (Map.Map a) where
+  liftRnf _ i = seq i ()
+
+instance  Ord a => IxContainerMinimal (Polymorphic  a) where
+  type Container (Polymorphic a) = Map.Map (Polymorphic  a)
+  alter = Map.alter
+  {-# INLINE alter #-}
+  empty = Map.empty
+
+instance  Ord a => IxContainer (Polymorphic  a) where
+  singleton = Map.singleton
+  size = Map.size
+  elems = Map.elems
+  keys = Map.keys
+  toList = Map.toList
+  member = Map.member
+  {-# INLINE member #-}
+  lookup = Map.lookup
+  {-# INLINE lookup #-}
+  insert = Map.insert
+  {-# INLINE insert #-}
+  insertWith = Map.insertWith
+  {-# INLINE insertWith #-}
+  mapMaybe = Map.mapMaybe
+  filter = Map.filter
+  differenceWith = Map.differenceWith
+  unionWith = Map.unionWith
+  intersectionWith = Map.intersectionWith
+  update = Map.update
+
+instance Ord a => OrderedContainer (Polymorphic a ) where
+  toAscList = Map.toAscList
+  toDescList = Map.toDescList
+  splitLookup = Map.splitLookup
+
+instance NFData1 IntMap.IntMap  where
+  liftRnf _ v = seq v ()
+
+instance  IxContainerMinimal Int where
+  type Container Int = IntMap.IntMap
+  empty = IntMap.empty
+  alter = IntMap.alter
+  {-# INLINE alter #-}
+
+instance  IxContainer Int where
+  singleton = IntMap.singleton
+  size = IntMap.size
+  elems = IntMap.elems
+  keys = IntMap.keys
+  toList = IntMap.toList
+  member = IntMap.member
+  {-# INLINE member #-}
+  lookup = IntMap.lookup
+  {-# INLINE lookup #-}
+  insert = IntMap.insert
+  {-# INLINE insert #-}
+  insertWith = IntMap.insertWith
+  {-# INLINE insertWith #-}
+  mapMaybe = IntMap.mapMaybe
+  filter = IntMap.filter
+  differenceWith = IntMap.differenceWith
+  unionWith = IntMap.unionWith
+  intersectionWith = IntMap.intersectionWith
+  update = IntMap.update
+
+
+instance  OrderedContainer Int where
+  toAscList = IntMap.toAscList
+  toDescList = IntMap.toDescList
+  splitLookup = IntMap.splitLookup
+
+instance NFData1 (HashMap.HashMap a) where
+  liftRnf _ v = seq v ()
+
+instance  (Eq a, Hashable a) => IxContainerMinimal (HashPolymorphic a) where
+  type Container (HashPolymorphic a) = HashMap.HashMap (HashPolymorphic a)
+  empty = HashMap.empty
+  alter = HashMap.alter
+  {-# INLINE alter #-}
+
+instance  (Eq a, Hashable a) => IxContainer (HashPolymorphic a) where
+  singleton = HashMap.singleton
+  size = HashMap.size
+  elems = HashMap.elems
+  keys = HashMap.keys
+  toList = HashMap.toList
+  member = HashMap.member
+  {-# INLINE member #-}
+  lookup = HashMap.lookup
+  {-# INLINE lookup #-}
+  insert = HashMap.insert
+  {-# INLINE insert #-}
+  insertWith = HashMap.insertWith
+  {-# INLINE insertWith #-}
+  mapMaybe = HashMap.mapMaybe
+  filter = HashMap.filter
+  differenceWith = HashMap.differenceWith
+  unionWith = HashMap.unionWith
+  intersectionWith = HashMap.intersectionWith
+  update = HashMap.update
+

--- a/src/main/Data/IxSet/Typed/Ix.hs
+++ b/src/main/Data/IxSet/Typed/Ix.hs
@@ -1,8 +1,19 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 module Data.IxSet.Typed.Ix
     ( Ix(..)
+    , Indexed(..)
     , insert
     , delete
     , fromList
+    , fromSet
     , insertList
     , deleteList
     , union
@@ -12,81 +23,119 @@ module Data.IxSet.Typed.Ix
     )
     where
 
-import Control.DeepSeq
+import qualified Data.IxSet.Typed.Container as Container
+import Data.IxSet.Typed.Container (Container,IxContainerMinimal, IxContainer,Polymorphic,HashPolymorphic) 
+import Data.Coerce
+import Data.Hashable
 import qualified Data.List as List
-import Data.Map (Map)
-import qualified Data.Map.Strict as Map
+import Data.IntMap  (IntMap)
+import Data.Map  (Map)
+import Data.HashMap.Lazy  (HashMap)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Prelude hiding (filter)
 
 -- the core data types
+class Coercible ix (IndexType a ix) =>  Indexed a ix where
+  type IndexType a ix 
+  type IndexType a ix = Container.Polymorphic ix  
+  ixFun :: a -> [ix]
+  ixRep :: ix -> IndexType a ix
+  ixRep =  coerce 
+  ixFunRep::  a -> [IndexType a ix]
+  ixFunRep f = ixRep @a @ix <$> ixFun f
 
--- | 'Ix' is a 'Map' from some key (of type 'ix') to a 'Set' of
+
+
+-- | 'Ix' is a 'Container' from some key (of type 'ix') to a 'Set' of
 -- values (of type 'a') for that key.
-newtype Ix ix a = Ix (Map ix (Set a))
+newtype Ix ix a = Ix (Container (IndexType a ix) (Set a))
 
-instance (NFData ix, NFData a) => NFData (Ix ix a) where
-  rnf (Ix m) = rnf m `seq` ()
+
 
 -- modification operations
 
--- | Convenience function for inserting into 'Map's of 'Set's as in
+-- | Convenience function for inserting into 'Container's of 'Set's as in
 -- the case of an 'Ix'.  If the key did not already exist in the
--- 'Map', then a new 'Set' is added transparently.
-insert :: (Ord a, Ord k)
-       => k -> a -> Map k (Set a) -> Map k (Set a)
-insert k v index = Map.alter (Just . maybe (Set.singleton v) (Set.insert v)) k index
+-- 'Container', then a new 'Set' is added transparently.
+insert :: (IxContainerMinimal k ,Ord a)
+       => k -> a -> Container k (Set a) -> Container k (Set a)
+insert k v index = Container.alter (Just . maybe (Set.singleton v) (Set.insert v)) k index
 {-# INLINE insert #-}
+{-# SPECIALIZE insert :: Ord a =>  Int -> a -> IntMap (Set a) -> IntMap (Set a) #-}
+{-# SPECIALIZE insert :: (Ord a, Ord k) => Polymorphic k -> a -> Map (Polymorphic k) (Set a) -> Map (Polymorphic k) (Set a)  #-}
+{-# SPECIALIZE insert :: (Ord a, Eq k, Hashable k) => HashPolymorphic k -> a -> HashMap (HashPolymorphic k) (Set a) -> HashMap (HashPolymorphic k) (Set a)  #-}
 
 -- | Helper function to 'insert' a list of elements into a set.
-insertList :: (Ord a, Ord k)
-           => [(k,a)] -> Map k (Set a) -> Map k (Set a)
+insertList :: (IxContainerMinimal k ,Ord a)
+           => [(k,a)] -> Container k (Set a) -> Container k (Set a)
 insertList xs index = List.foldl' (\m (k,v)-> insert k v m) index xs
 {-# INLINE insertList #-}
+{-# SPECIALIZE insertList :: Ord a =>  [(Int ,a)] -> IntMap (Set a) -> IntMap (Set a) #-}
+{-# SPECIALIZE insertList :: (Ord a, Ord k) => [(Polymorphic k,a)] -> Map (Polymorphic k) (Set a) -> Map (Polymorphic k) (Set a)  #-}
+{-# SPECIALIZE insertList :: (Ord a, Eq k, Hashable k) => [(HashPolymorphic k,a)] -> HashMap (HashPolymorphic k) (Set a) -> HashMap (HashPolymorphic k) (Set a)  #-}
 
 -- | Helper function to create a new index from a list.
-fromList :: (Ord a, Ord k) => [(k, a)] -> Map k (Set a)
+fromList :: (IxContainerMinimal k ,Ord a) => [(k, a)] -> Container k (Set a)
 fromList xs =
-  List.foldl' (\m (k,v) -> insert k v m)  Map.empty  xs
+  List.foldl' (\m (k,v) -> insert k v m)  Container.empty  xs
 {-# INLINE fromList #-}
+{-# SPECIALIZE fromList :: Ord a =>  [(Int ,a)] -> IntMap (Set a) #-}
+{-# SPECIALIZE fromList :: (Ord a, Ord k) => [(Polymorphic k,a)] -> Map (Polymorphic k) (Set a)  #-}
+{-# SPECIALIZE fromList :: (Ord a, Eq k, Hashable k) => [(HashPolymorphic k,a)] -> HashMap (HashPolymorphic k) (Set a)  #-}
 
--- | Convenience function for deleting from 'Map's of 'Set's. If the
--- resulting 'Set' is empty, then the entry is removed from the 'Map'.
-delete :: (Ord a, Ord k)
-       => k -> a -> Map k (Set a) -> Map k (Set a)
-delete k v index = Map.update remove k index
+fromSet :: forall a k. (IxContainerMinimal k,  Ord a) =>  (a -> [k] )-> Set a ->Container k (Set a)
+fromSet f xs = fromList (concatMap (\i ->(,i) <$> f i ) (Set.toList xs ))
+{-# INLINE fromSet #-}
+{-# SPECIALIZE fromSet ::  Ord a =>  (a -> [Int] ) -> Set a -> IntMap (Set a) #-}
+{-# SPECIALIZE fromSet :: (Ord a, Ord k) => (a -> [Polymorphic k] ) ->Set a ->  Map (Polymorphic k) (Set a)  #-}
+{-# SPECIALIZE fromSet :: (Ord a, Eq k, Hashable k) => (a -> [HashPolymorphic k] ) ->Set a -> HashMap (HashPolymorphic k) (Set a) #-}
+
+
+
+-- | Convenience function for deleting from 'Container's of 'Set's. If the
+-- resulting 'Set' is empty, then the entry is removed from the 'Container'.
+delete :: (IxContainer k ,Ord a)
+       => k -> a -> Container k (Set a) -> Container k (Set a)
+delete k v index = Container.update remove k index
     where
     remove set = let set' = Set.delete v set
                  in if Set.null set' then Nothing else Just set'
 {-# INLINE delete #-}
+{-# SPECIALIZE delete :: Ord a =>  Int -> a -> IntMap (Set a) -> IntMap (Set a) #-}
+{-# SPECIALIZE delete :: (Ord a, Ord k) => Polymorphic k -> a -> Map (Polymorphic k) (Set a) -> Map (Polymorphic k) (Set a)  #-}
+{-# SPECIALIZE delete :: (Ord a, Eq k, Hashable k) => HashPolymorphic k -> a -> HashMap (HashPolymorphic k) (Set a) -> HashMap (HashPolymorphic k) (Set a)  #-}
 
 -- | Helper function to 'delete' a list of elements from a set.
-deleteList :: (Ord a, Ord k)
-           => [(k,a)] -> Map k (Set a) -> Map k (Set a)
+deleteList :: (IxContainer k , Ord a)
+           => [(k,a)] -> Container k (Set a) -> Container k (Set a)
 deleteList xs index = List.foldl' (\m (k,v) -> delete k v m) index xs
 {-# INLINE deleteList #-}
 
 -- | Takes the union of two sets.
-union :: (Ord a, Ord k)
-       => Map k (Set a) -> Map k (Set a) -> Map k (Set a)
-union index1 index2 = Map.unionWith Set.union index1 index2
+union :: (IxContainer k , Ord a)
+       => Container k (Set a) -> Container k (Set a) -> Container k (Set a)
+union index1 index2 = Container.unionWith Set.union index1 index2
+{-# INLINE union #-}
 
 -- | Takes the intersection of two sets.
-intersection :: (Ord a, Ord k)
-             => Map k (Set a) -> Map k (Set a) -> Map k (Set a)
-intersection index1 index2 = Map.filter (not . Set.null) $
-                             Map.intersectionWith Set.intersection index1 index2
+intersection :: (IxContainer k , Ord a)
+             => Container k (Set a) -> Container k (Set a) -> Container k (Set a)
+intersection index1 index2 = Container.filter (not . Set.null) $
+                             Container.intersectionWith Set.intersection index1 index2
+{-# INLINE intersection #-}
 
 -- | Takes the difference of two sets.
-difference :: (Ord a, Ord k)
-             => Map k (Set a) -> Map k (Set a) -> Map k (Set a)
-difference index1 index2 = Map.differenceWith diff index1 index2
+difference :: (IxContainer k ,Ord a)
+             => Container k (Set a) -> Container k (Set a) -> Container k (Set a)
+difference index1 index2 = Container.differenceWith diff index1 index2
   where diff set1 set2 = let diffSet = Set.difference set1 set2 in
                             if Set.null diffSet then Nothing else Just diffSet
+{-# INLINE difference #-}
 
 -- | Filters the sets by restricting to the elements in the provided set.
-filterFrom :: (Ord a) => Set a -> Map k (Set a) -> Map k (Set a)
-filterFrom s index = Map.mapMaybe g index
+filterFrom :: (IxContainer k ,Ord a) => Set a -> Container k (Set a) -> Container k (Set a)
+filterFrom s index = Container.mapMaybe g index
   where g set = let set' = Set.intersection set s
                 in if Set.null set' then Nothing else Just set'
+{-# INLINE filterFrom #-}

--- a/test.hs
+++ b/test.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+module Main where
+import Data.IxSet.Typed as IS
+-- import Data.IxSet.Typed.Container (HashPolymorphic(..))
+import Control.Exception
+import qualified Data.Set as Set
+import Data.Maybe
+import Data.Time
+import qualified Data.List as L
+
+
+data Account 
+ = Account 
+   { accId ::Int 
+   , balance ::  Double
+   , users ::  [String] 
+   }deriving(Show)
+
+instance Eq Account where
+  i == j = accId i == accId j 
+
+instance Ord Account where
+  compare i j = compare (accId i) (accId j )
+
+type AccountMap = IxSet '[Int,Double,String] Account
+
+instance Indexed Account Int where
+  -- type IndexType Account Int = Int
+  ixFun = pure . accId 
+
+instance Indexed Account Double where
+  ixFun = pure . balance 
+
+instance Indexed Account String where
+  -- type IndexType Account String = HashPolymorphic String 
+  ixFun = users 
+
+measure t f = do
+  t0 <-  getCurrentTime
+  i <- evaluate f
+  tf <-  getCurrentTime
+  putStrLn $ t ++ ": " ++ show (diffUTCTime tf t0)
+
+main = do 
+  let i0 = empty :: AccountMap
+      i1 = L.foldl' (\s i -> insert (Account (i  :: Int) 0 [replicate 36 'a'] ) s) i0 [0..200000]
+      i2 = L.foldl' (\s v -> fst $ alterIx (round v  :: Int) (Just . maybe (error "no account") ((\i -> i {balance = v + 1})))  s ) i1 [0..20000]
+    --  i2 = L.foldl' (\s v -> fst $ alterIx (1 :: Int) (Just . maybe (error "no account") (Set.mapMonotonic (\i -> i {balance = v + 1})))  s ) i1 [0..20000]
+      i3 = L.foldl' (\s v -> updateIx (round v  :: Int) ((fromJust $ IS.lookup (round v :: Int) s)  {balance = v + 1})  s ) i1 [0..20000]
+
+  measure "create" i1
+  measure "alter" i2  
+  measure "update" i3
+  print (size i1)
+  print (i2 == i3)
+


### PR DESCRIPTION
Extend the library to support selecting the type of the container user per index. This allows using specialized containers like IntMap for newtypes of Int, HashMap for Text like types and any other kind of KV container 

This is also significantly faster then using Map k a, naive microbenchmarks show 50% improvements on update, alter and 30% lookup
